### PR TITLE
Add a failing test to sanity-check order of quantile values

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -15,10 +15,6 @@ var app = express();
 app.use(helmet());
 app.use(auth);
 
-// authentication middleware
-
-app.listen((process.env.MIDAAS_API_PORT || 8080), function(){
-  console.log("app listening on port " + (process.env.MIDAAS_API_PORT || 8080));
-});
-
 app.use('/income', router);
+
+module.exports = app;

--- a/index.js
+++ b/index.js
@@ -1,0 +1,8 @@
+var app = require('./app');
+
+
+var port = process.env.MIDAAS_API_PORT || 8080;
+
+app.listen(port, function(){
+  console.log("app listening on port " + port);
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Midaas API Express App",
   "main": "app/index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha"
   },
   "repository": {
     "type": "git",
@@ -25,5 +25,13 @@
     "lodash": "^4.11.1",
     "numeraljs": "^1.5.6",
     "pg": "^4.5.3"
+  },
+  "devDependencies": {
+    "chai": "^3.5.0",
+    "chai-sorted": "^0.1.0",
+    "mocha": "^2.5.3",
+    "supertest": "^1.2.0",
+    "tap-prettify": "0.0.2",
+    "tape": "^4.5.1"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,34 @@
+var app = require('../app');
+var request = require('supertest')(app);
+var chai = require('chai'),
+  assert = chai.assert,
+  expect = chai.expect;
+var _ = require('lodash');
+var util = require('util');
+
+chai.use(require('chai-sorted'));
+
+describe('income', function() {
+    describe('quantiles', function() {
+        it('should have ascending values sorted in the same direction as the quantiles', function(done) {
+          process.env.MIDAAS_API_PORT = 9999;
+          process.env.MIDAAS_API_USERNAME = 'foo';
+          process.env.MIDAAS_API_PASSWORD = 'bar';
+          request
+            .get('/income/quantiles')
+            .auth('foo', 'bar')
+            .set('Accept', 'application/json')
+            .expect(200)
+            .end(function(err, res) {
+              var quantiles = _.toPairs(res.body.overall);
+              // pull just the values (income) from the quantiles
+              var vals = _.map(quantiles, function(o) { return o[1]; });
+              var vals_srt = _.chain(vals).clone().sortBy().value();
+
+              expect(vals).to.deep.equal(vals_srt);
+
+              done();
+            });
+        });
+    });
+});


### PR DESCRIPTION
Also added a working Mocha test setup. Run `npm test`, `mocha` or `mocha --watch` to run tests. You'll also need to `npm install -g mocha` first.