### PR TITLE
Fixed appendWhereClause for comparisons by passing compare value

### DIFF
--- a/app/controllers/quantile.js
+++ b/app/controllers/quantile.js
@@ -28,7 +28,7 @@ var quantileController = {
     delete queryParams["compare"];
 
     var sql = "SELECT QUANTILE, INCOME, " + compare + " FROM PUMS_2014_Quantiles";
-    sql = utils.appendCompareWhereClause(sql, queryParams) + " ORDER BY QUANTILE::INT ASC;";
+    sql = utils.appendWhereClause(sql, queryParams, compare) + " ORDER BY QUANTILE::INT ASC;";
     pg.connect(conn_options, function(err, client, next) {
       if(err) { return next(err); }
 

--- a/app/utils.js
+++ b/app/utils.js
@@ -110,7 +110,7 @@ var validateQueryParams = function(queryParams, callback) {
   return callback();
 }
 
-var appendWhereClause = function(sql, queryParams) {
+var appendWhereClause = function(sql, queryParams, compare) {
   var defaultParams = {
     'state': '',
     'sex': '',
@@ -119,6 +119,7 @@ var appendWhereClause = function(sql, queryParams) {
   };
   sql += " WHERE ";
   sqlWhere = [];
+  defaultParams = _.omit(defaultParams, [compare])
   _.forOwn(queryParams, function(value, key) {
     if (!(key.toLowerCase() === "quantile" && value === "")) {
       defaultParams= _.omit(defaultParams, [key]);
@@ -133,19 +134,6 @@ var appendWhereClause = function(sql, queryParams) {
   return sql;
 };
 
-var appendCompareWhereClause = function(sql, queryParams) {
-  if(!_.isEmpty(queryParams)) {
-    sql += " WHERE ";
-    sqlWhere = [];
-    _.forOwn(queryParams, function(value, key) {
-      if (!(key.toLowerCase() === "quantile" && value === "")) {
-        sqlWhere.push(key + "='" + value + "'");
-      }
-    });
-    sql += sqlWhere.join(" AND ");
-  }
-  return sql;
-};
 var getTranslatedWhereClause = function(queryParams) {
   var whereClause = [
     translateStateToQuery(queryParams["state"]),
@@ -176,7 +164,6 @@ var formatIncome = function(income) {
  ***************************************************************/
 
 module.exports.appendWhereClause = appendWhereClause;
-module.exports.appendCompareWhereClause = appendCompareWhereClause;
 module.exports.appendTranslatedWhereClause = appendTranslatedWhereClause;
 module.exports.validateQueryParams = validateQueryParams;
 module.exports.formatIncome = formatIncome;


### PR DESCRIPTION
@arowla: It turns out it needed the same fix with the exception of omitting the parameter that it's being compared on which wasn't in the queryParams and that's why it broke the first time. So reverting to using a single function for both. I'm going to write a test for this tomorrow that takes the values from simple queries and checks them against those from a comparison query but I did some manual point to point checking and seems to work ok now. 